### PR TITLE
Add about page

### DIFF
--- a/pages/about.md
+++ b/pages/about.md
@@ -1,0 +1,7 @@
+---
+title: "About me"
+permalink: about/
+---
+# About me
+
+Experienced .Net software engineer and technical lead now building things in Ruby, NodeJS and Java for the Environment Agency. Initially working with financial and mobile solution POD and POS systems, I now help make 'better places' by building the next generation of government digital services.


### PR DESCRIPTION
Initial (and temporary!) version of an **About Me** page, added essentially to fix the broken link in the current layout.