### PR TITLE
Add contact page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,7 +10,7 @@
         <ul>
             <li><a href="/">Home</a></li>
             <li><a href="/about">About</a></li>
-            <li><a href="/cv">CV</a></li>
+            <li><a href="/contact">Contact</a></li>
             <li><a href="/blog">Blog</a></li>
         </ul>
     </nav>

--- a/pages/contact.md
+++ b/pages/contact.md
@@ -1,0 +1,9 @@
+---
+title: "Contact me"
+permalink: contact/
+---
+# Contact me
+
+The best way to contact me is Twitter [@AlanCruikshanks](https://twitter.com/AlanCruikshanks).
+
+You can also grab me at [LinkedIn](https://www.linkedin.com/in/alan-cruikshanks/) if you prefer.


### PR DESCRIPTION
Initial (and temporary!) version of a **Contact Me** page, added essentially to replace the link to CV in the current layout.