### PR TITLE
Add integration to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+sudo: false
+language: ruby
+rvm:
+  - 2.3.1
+
+# Travis CI clones repositories to a depth of 50 commits, which is only really
+# useful if you are performing git operations.
+# https://docs.travis-ci.com/user/customizing-the-build/#Git-Clone-Depth
+git:
+  depth: 3
+
+# enable Bundler caching
+# https://docs.travis-ci.com/user/languages/ruby#Caching-Bundler
+cache: bundler
+
+script:
+  - bundle exec jekyll build
+  - bundle exec htmlproofer ./_site --only-4xx --check-html # --check-favicon
+
+env:
+  global:
+    - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,12 @@
 source 'https://rubygems.org'
 
 gem 'github-pages', group: :jekyll_plugins
+
+group :test do
+  # Used to test the sit as part of CI. Run
+  # bundle exec htmlproofer ./_site --only-4xx --check-html
+  # and htmlproofer will check the validity of all the HTML and that the links
+  # all work (specifically that they don't return a 5xx error. 4xx is fine as
+  # its assumed the called service is temporarily down)
+  gem "html-proofer"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     colorator (1.1.0)
+    colored (1.2)
     ethon (0.10.1)
       ffi (>= 1.3.0)
     execjs (2.7.0)
@@ -73,6 +74,15 @@ GEM
     html-pipeline (2.5.0)
       activesupport (>= 2)
       nokogiri (>= 1.4)
+    html-proofer (3.6.0)
+      activesupport (>= 4.2, < 6.0)
+      addressable (~> 2.3)
+      colored (~> 1.2)
+      mercenary (~> 0.3.2)
+      nokogiri (~> 1.5)
+      parallel (~> 1.3)
+      typhoeus (~> 0.7)
+      yell (~> 2.0)
     i18n (0.8.1)
     jekyll (3.4.3)
       addressable (~> 2.4)
@@ -169,6 +179,7 @@ GEM
       mini_portile2 (~> 2.1.0)
     octokit (4.6.2)
       sawyer (~> 0.8.0, >= 0.5.3)
+    parallel (1.11.1)
     pathutil (0.14.0)
       forwardable-extended (~> 2.6)
     public_suffix (2.0.5)
@@ -189,12 +200,14 @@ GEM
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
     unicode-display_width (1.1.3)
+    yell (2.0.7)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   github-pages
+  html-proofer
 
 BUNDLED WITH
    1.14.6

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # My personal website
 
+[![Build Status](https://travis-ci.org/Cruikshanks/cruikshanks.github.io.svg?branch=master)](https://travis-ci.org/Cruikshanks/cruikshanks.github.io)
+
 I've moved to using [GitHub Pages](https://pages.github.com/) to host my personal site, backed by [Jekyll](https://jekyllrb.com/).
 
 I have only just set this up so expect numerous changes in the coming days.

--- a/_config.yml
+++ b/_config.yml
@@ -7,3 +7,7 @@ exclude:
   - Gemfile.lock
   - LICENSE
   - README.md
+  # Have to include this else you will break the Travis CI build. This is
+  # because Travis bundles all gems in the vendor directory on its build
+  # servers, which Jekyll will mistakenly read and explode on!
+  - vendor

--- a/_posts/2017-03-20-jekyll-and-github-pages-oh-my.md
+++ b/_posts/2017-03-20-jekyll-and-github-pages-oh-my.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Jekyll and GitHub pages oh my!"
 date: 2017-03-30
+permalink: blog/jekyll-and-github-pages-oh-my/
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam leo ipsum, imperdiet quis elementum interdum, tristique vel turpis. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Pellentesque vel nulla ipsum. Proin sagittis imperdiet rutrum. Nunc in dictum lacus. Suspendisse pulvinar molestie magna in mollis. Donec euismod lectus vitae ante aliquam, et lobortis nisi rhoncus.


### PR DESCRIPTION
To ensure future changes don't break the site, this adds the gem [html-proofer](https://github.com/gjtorikian/html-proofer) and a `.travis.yml` file to conifgure how we integrate with Travis.

**Html-proofer** allows me to test the site locally, and using the `.travis.yml` file I can also have it run automatically in CI for each PR and merge to master.