### PR TITLE
Fix broken url for og:image tag for rich previews

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -23,7 +23,7 @@
     <meta name="description" content="{{ page.description }}" />
     <meta property="og:title" content="{{ page.title }}" />
     <meta property="og:description" content="{{ page.description }}" />
-    <meta property="og:image" content="http://cruikshanks.com/assets/images/default_rich_preview.png" />
+    <meta property="og:image" content="http://cruikshanks.co.uk/assets/images/default_rich_preview.png" />
     <!-- Added these extra tags having looked at http://ogp.me/ -->
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="cruikshanks.co.uk" />


### PR DESCRIPTION
Spotted that the link to an image for rich previews was using .com rather than .co.uk and hence returning a completly different (and wrong) image.

This change fixes the typo.