### PR TITLE
Add missing title meta tag to default layout

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,6 +20,7 @@
 
     <!-- Rich preview support as per https://medium.com/@richardoosterhof/how-to-optimize-your-site-for-rich-previews-527ed13a6d69  -->
     <!-- and https://richpreview.com/ -->
+    <meta name="title" content="{{ page.title }}" />
     <meta name="description" content="{{ page.description }}" />
     <meta property="og:title" content="{{ page.title }}" />
     <meta property="og:description" content="{{ page.description }}" />


### PR DESCRIPTION
When starting to write a post about how to build support into your site for rich previews in apps that support them, I spotted that I had missed the `title` tag from the implementation.

`og:title` was covered, but reading back through the [original article](https://medium.com/@richardoosterhof/how-to-optimize-your-site-for-rich-previews-527ed13a6d69) which got me started I realised I had omitted adding a basic `<meta name='title' />` tag.

This change fixes the omission.