### PR TITLE
Add missing og:url meta tag to default layout

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -27,6 +27,7 @@
     <meta property="og:image" content="http://cruikshanks.co.uk/assets/images/default_rich_preview.png" />
     <!-- Added these extra tags having looked at http://ogp.me/ -->
     <meta property="og:type" content="website" />
+    <meta property="og:url" content="http://cruikshanks.co.uk/{{ page.permalink }}" />
     <meta property="og:site_name" content="cruikshanks.co.uk" />
     <meta property="og:locale" content="en_GB" />
     <!-- Also add specific twitter support as per https://dev.twitter.com/cards/types/summary -->


### PR DESCRIPTION
When starting to write a post about how to build support into your site for rich previews in apps that support them, I spotted that I had missed the `url` tag from the implementation.

Double checking the [Open graph requirements](http://ogp.me/) it lists title, type, image and url as the four required properties for a page to support **Open graph**.

I spotted that my pages were missing `url` so this change resolves the omission.