### PR TITLE
Add Disqus support to post template

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -7,6 +7,28 @@ layout: default
 <div class="post">
   {{ content }}
 </div>
+
+<!-- disqus code - start -->
+<div id="disqus_thread"></div>
+<script>
+  /**
+  *  RECOMMENDED CONFIGURATION VARIABLES: EDIT AND UNCOMMENT THE SECTION BELOW TO INSERT DYNAMIC VALUES FROM YOUR PLATFORM OR CMS.
+  *  LEARN WHY DEFINING THESE VARIABLES IS IMPORTANT: https://disqus.com/admin/universalcode/#configuration-variables*/
+  var disqus_config = function () {
+    this.page.url = "{{ page.url }}";  // Replace PAGE_URL with your page's canonical URL variable
+    this.page.identifier = "{{ page.id }}"; // Replace PAGE_IDENTIFIER with your page's unique identifier variable
+  };
+
+  (function() { // DON'T EDIT BELOW THIS LINE
+    var d = document, s = d.createElement('script');
+    s.src = 'https://cruikshanks.disqus.com/embed.js';
+    s.setAttribute('data-timestamp', +new Date());
+    (d.head || d.body).appendChild(s);
+  })();
+</script>
+<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+<!-- disqus code - end -->
+
 <div class="license">
   <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons Licence" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />
   <span class="license-title" xmlns:dct="http://purl.org/dc/terms/" href="http://purl.org/dc/dcmitype/Text" property="dct:title" rel="dct:type">{{ page.title }}</span> by <a xmlns:cc="http://creativecommons.org/ns#" href="http://cruikshanks.co.uk/" property="cc:attributionName" rel="cc:attributionURL">Alan Cruikshanks</a> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.<br />Based on the work at <a xmlns:dct="http://purl.org/dc/terms/" href="http://cruikshanks.co.uk{{ page.url }}" rel="dct:source">http://cruikshanks.co.uk{{ page.url }}</a>.


### PR DESCRIPTION
This adds support for as per issue https://github.com/Cruikshanks/cruikshanks.github.io/issues/29.

The simplest solution was to [Disqus](https://disqus.com/) rather than trying to build my own, or implement an add on. By simply adding some script to my layout I have commenting and an administrative backend so job done!