### PR TITLE
Ensure Disqus url value is absolute not relative

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -15,7 +15,7 @@ layout: default
   *  RECOMMENDED CONFIGURATION VARIABLES: EDIT AND UNCOMMENT THE SECTION BELOW TO INSERT DYNAMIC VALUES FROM YOUR PLATFORM OR CMS.
   *  LEARN WHY DEFINING THESE VARIABLES IS IMPORTANT: https://disqus.com/admin/universalcode/#configuration-variables*/
   var disqus_config = function () {
-    this.page.url = "{{ page.url }}";  // Replace PAGE_URL with your page's canonical URL variable
+    this.page.url = "http://cruikshanks.co.uk{{ page.url }}";  // Replace PAGE_URL with your page's canonical URL variable
     this.page.identifier = "{{ page.id }}"; // Replace PAGE_IDENTIFIER with your page's unique identifier variable
   };
 


### PR DESCRIPTION
Hadn't spotted that the value I was setting for `this.page.url` as not an absolute one. This is a requirement of [Disqus](https://disqus.com) so this change fixes the issue.