### PR TITLE
Fix htmlproofer check failing in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,11 @@ cache: bundler
 
 script:
   - bundle exec jekyll build
-  - bundle exec htmlproofer ./_site --only-4xx --check-html # --check-favicon
+  # The argument below mean
+  # --only-4xx Only reports errors for links that fall within the 4xx status code range
+  # --check-html Enables HTML validation errors from Nokogiri
+  # --assume-extension Automatically add extension (e.g. `.html`) to file paths, to allow extensionless URLs (as supported by Jekyll 3 and GitHub Pages)
+  - bundle exec htmlproofer ./_site --only-4xx --check-html --assume-extension
 
 env:
   global:

--- a/_posts/2017-10-03-docker-for-development.md
+++ b/_posts/2017-10-03-docker-for-development.md
@@ -3,7 +3,7 @@ layout: post
 title: "Docker for development"
 description: "Why Docker for development is different, with examples"
 date: 2017-10-03
-permalink: blog/docker-for-development
+permalink: blog/docker-for-development/
 ---
 
 Using [Docker](https://www.docker.com/) for local development is different to actually building images that you expect to be deployed and run as containers elsewhere.
@@ -298,4 +298,3 @@ Using **Docker** for development will help you and your team avoid *it works on 
 The examples here are very basic though, and its likely you will also depend on other services and tools. But pretty much every other example of using **Docker** for development immediately launches into using [Compose](https://docs.docker.com/compose/), so I wanted to provide a stripped back example. I hope it helps those like me who just wanted to get to grips with what you need to conisder just getting 'your' app up and running.
 
 Finally you will have to get used to calling **Docker** to start your apps, rather than your typical `ruby server.js` or `npm start`. And as you've seen the command can be complex so bear in mind how you can keep repeating it.
-


### PR DESCRIPTION
Having re-read the documentation for htmlproofer the command it suggests running for Jekyll based projects is `htmlproofer --assume-extension ./_site`

The key bit missing from my command `--assume-extension`. From the docs this means

> Automatically add extension (e.g. `.html`) to file paths, to allow extensionless URLs (as supported by Jekyll 3 and GitHub Pages)

I also spotted a difference in how I had set the permalink attribute in the docker for development post (the one that always failed before) which having fixed led to Jekyll building it the same as the other posts.